### PR TITLE
Improve Semaphore's command handling

### DIFF
--- a/lib/test_boosters/boosters/rspec.rb
+++ b/lib/test_boosters/boosters/rspec.rb
@@ -28,7 +28,7 @@ module TestBoosters
         @rspec_options ||= begin
           output_formatter = ENV.fetch("TB_RSPEC_FORMATTER", "documentation")
           # rubocop:disable LineLength
-          "#{ENV["TB_RSPEC_OPTIONS"]} --format #{output_formatter} --require #{formatter_path} --format SemaphoreFormatter --out #{report_path}"
+          "#{ENV["TB_RSPEC_OPTIONS"]} --format #{output_formatter} --require #{formatter_path} --format SemaphoreFormatter --out #{report_path} --profile"
         end
       end
 

--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -10,17 +10,23 @@ module TestBoosters
         @split_configuration_path = split_configuration_path
         @file_pattern = file_pattern
         @job_count = job_count
-        @exclude_path = [ENV['BOOSTERS_EXCLUDE_PATH']]
+        @exclude_path = ['spec/features/']
       end
 
       def env_handler
         last_msg = `git log -1`
 
+        if %w[master develop release].include?(ENV['BRANCH_NAME'])
+          @exclude_path.delete('spec/features/')
+        end
+        if ENV['SEMAPHORE_TRIGGER_SOURCE'].eql?('manual')
+          @exclude_path.delete('spec/features/')
+        end
         if last_msg.include?('[cukes off]')
           @exclude_path << '.feature'
         end
         if last_msg.include?('[regression]')
-          @exclude_path.delete(ENV['BOOSTERS_EXCLUDE_PATH'])
+          @exclude_path.delete('spec/features/')
         end
         if last_msg.include?('[spec off]')
           @exclude_path << '_spec.rb'

--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -15,16 +15,14 @@ module TestBoosters
 
       def env_handler
         last_msg = `git log -1`
-        start = last_msg =~ /\[/
-        ending = last_msg =~ /\]/
-        command = last_msg[start.to_i..ending.to_i]
 
-        case command
-        when '[cukes off]'
+        if last_msg.include?('[cukes off]')
           @exclude_path << '.feature'
-        when '[regression]'
+        end
+        if last_msg.include?('[regression]')
           @exclude_path.delete(ENV['BOOSTERS_EXCLUDE_PATH'])
-        when '[spec off]'
+        end
+        if last_msg.include?('[spec off]')
           @exclude_path << '_spec.rb'
         end
       end

--- a/lib/test_boosters/job.rb
+++ b/lib/test_boosters/job.rb
@@ -32,15 +32,6 @@ module TestBoosters
 
         return 0
       end
-
-      # TODO: do this properly, hack this in for now to get it working
-      if @command =~ /cucumber/
-        cmd = "if [ -x ./script/semaphore/cukes_off.rb ] && ./script/semaphore/cukes_off.rb; then echo 'CUKES OFF'; else bundle exec cucumber --strict -f rerun --out rerun.txt #{files.join(" ")} || bundle exec cucumber --strict @rerun.txt; fi"
-        TestBoosters::Shell.execute(cmd)
-      else
-        TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
-      end
     end
-
   end
 end

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "2.3.1".freeze
+  VERSION = "2.3.2".freeze
 end

--- a/spec/lib/test_boosters/file_exclude_spec.rb
+++ b/spec/lib/test_boosters/file_exclude_spec.rb
@@ -3,48 +3,50 @@ require 'spec_helper'
 describe 'Excluding a path from running when' do
   subject { distributor.all_files.any? { |f| f.include? banished_dir } }
 
-  let(:banished_dir) { '/integration/' }
+  let(:banished_dir) { '/features/' }
   let(:file_pattern) { 'spec/**/*_spec.rb' } # The hardcoded pattern for rspec boosters
   let(:distributor) { TestBoosters::Files::Distributor.new(nil, file_pattern, 12) }
 
-  after { ENV.delete('BOOSTERS_EXCLUDE_PATH') }
+  after do
+    ENV.delete('SEMAPHORE_TRIGGER_SOURCE')
+    ENV.delete('BRANCH_NAME')
+  end
 
-  context 'an exclusion path is specified' do
-    before { ENV['BOOSTERS_EXCLUDE_PATH'] = 'spec/integration/' }
+  context 'on a core branch' do
+    before { ENV['BRANCH_NAME'] = 'master' }
+
+    it 'files filtered out correctly' do
+      expect(subject).to be true
+    end
+  end
+
+  context 'on an arbitrary branch' do
+    before { ENV['BRANCH_NAME'] = 'abracadabra' }
 
     it 'files filtered out correctly' do
       expect(subject).to be false
     end
   end
 
-  context 'a specific file is passed' do
-    before { ENV['BOOSTERS_EXCLUDE_PATH'] = 'cucumber_spec.rb' }
+  context 'when manually rebuilt' do
+    before { ENV['SEMAPHORE_TRIGGER_SOURCE'] = 'manual' }
 
-    it 'files filtered out correctly' do
-      expect(subject).to be true
-      expect(distributor.all_files).not_to include('spec/integration/cucumber_spec.rb')
-    end
-  end
-
-  context 'no exclusion path is specified' do
-    it 'nothing filtered out' do
+    it 'files filtered correctly' do
       expect(subject).to be true
     end
   end
 
-  context 'an empty exlusion path is passed' do
-    before { ENV['BOOSTERS_EXCLUDE_PATH'] = '' }
+  context 'an automated push' do
+    before { ENV['SEMAPHORE_TRIGGER_SOURCE'] = 'push' }
 
-    it 'nothing filtered out' do
-      expect(subject).to be true
+    it 'files filtered correctly' do
+      expect(subject).to be false
     end
   end
 
-  context 'a nil path is passed' do
-    before { ENV['BOOSTERS_EXCLUDE_PATH'] = nil }
-
-    it 'nothing filtered out' do
-      expect(subject).to be true
+  context 'nothing is specified' do
+    it 'features filtered out' do
+      expect(subject).to be false
     end
   end
 end


### PR DESCRIPTION
In a previous update to the Semaphore boosters, functionality was added so that spec/features/ only ran on develop, master and release. After some discussion with Kostya and Andrew, further flexibility was needed, so through this PR test boosters will:

- Not require any setup commands in the 'Project Settings' of Semaphore. All setup is now done within the ruby files.
- RSpec profiler is turned on, making it a lot easier to identify hanging specs and to target specs for optimistation

- Exclude spec/features/ from executing by default
- Include spec/features/ in execution IF
  - The branch is master, develop or release
  - The build was manually created (i.e. not an automated push, the user clicked 'Rebuild this revision')

And be able to process the Git commit commands:
- [regression] will force turn on spec/features/ for said build.
- [cukes off] does the same thing it does now, but the code executing it is much cleaner.
- [spec off] turns off the RSpec boosters, so only cukes are run.

It's now very easy to add more commands to the boosters so if you have any requests please let me know.