### PR TITLE
Feature/file exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ There are two environment variables that need to be set in order to do this:
 
 `REGRESSION_PATH` is the path that the test boosters will ignore unless a full test suite is being run.
 
-`EXEMPT_BRANCHES` contains a csv list of branches that will always run a full test suite- i.e. they will ignore the REGRESSION_PATH exclusion. This is very useful for branches like master, release or develop where thoroughness is more important than execution time.
+`EXEMPT_BRANCHES` contains a csv list of branches that will always run a full test suite - i.e. they will ignore the REGRESSION_PATH exclusion. This is very useful for branches like master, release or develop where thoroughness is more important than execution time.
 
 An example use of this would be a company that doesn't want their Capybara tests (all located in spec/features/) to run unless necessary. This way, Semaphore's build time can be reduced on all branches that don't need total build-accuracy. In this case, the company could use Semaphore's environment variable setter to enable:
 
@@ -121,7 +121,7 @@ An example use of this would be a company that doesn't want their Capybara tests
 
 `EXEMPT_BRANCHES=master,release,develop`
 
-Additionally, the REGRESSION_PATH will be ignored if the build was manually created- meaning it was created by someone clicking 'Rebuild last revision' on Semaphore.
+Additionally, the REGRESSION_PATH will be ignored if the build was manually created - meaning it was created by someone clicking 'Rebuild last revision' on Semaphore.
 
 ### Commit Directives
 
@@ -130,20 +130,20 @@ Further, test execution can be customised by commit directives. Commit directive
 - [ci skip]
   - Semaphore will not process this commit, will not create a build revision of it.
 - [cukes off]
-  - Cucumber tests wont run. This directive tells Semaphore not to execute any cucumber test files.
+  - Cucumber tests will not be run. This directive tells Semaphore not to execute any cucumber test files.
 - [specs off]
-  - Specs wont run. Same purpose as cukes off but for specs.
+  - Specs will not be run. Same purpose as cukes off but for specs.
 - [minitest off]
-  - Minitest wont run.
+  - Minitest tests will not be run.
 - [exunit off]
-  - ExUnit tests wont run.
+  - ExUnit tests will not be run.
 - [gotest off]
-  - GoTests wont run.
+  - GoTests tests will not be run.
 - [regression]
   - The REGRESSION_PATH is ignored, a full test-suite is run for this build. Useful if you want to be certain your code is green before pushing to release, master etc.
 
 These commit directives can be stacked as much as you would like, but be wary of using conflicting directives that might have unexpected behaviour.
-For example if `[regression]` and `[ci skip]` are both passed, ci skip will trump and no build revision will be made.
+For example if `[regression]` and `[ci skip]` are both passed, `[ci skip]` will trump and no build revision will be made.
 
 In an example where a developer did not want their specs to run on a certain commit, they could use the commit message:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Test Booster basics:
   - [What are Test Boosters](#what-are-test-boosters)
   - [Split Configuration](#split-configuration)
   - [Leftover Files](#split-configuration)
+  - [Altering Test Paths](#altering-test-paths)
+  - [Commit Directives](#commit-directives)
 
 Test Boosters:
 
@@ -102,6 +104,57 @@ rspec_booster --job 1/3
 ```
 
 Booster will distribute your leftover files uniformly across jobs.
+
+### Altering Test Paths
+
+There is always a trade-off between testing time and test thoroughness.
+To make this more flexible, test boosters have the ability to dynamically assign test paths based on environment variables.
+There are two environment variables that need to be set in order to do this:
+
+`REGRESSION_PATH` is the path that the test boosters will ignore unless a full test suite is being run.
+
+`EXEMPT_BRANCHES` contains a csv list of branches that will always run a full test suite- i.e. they will ignore the REGRESSION_PATH exclusion. This is very useful for branches like master, release or develop where thoroughness is more important than execution time.
+
+An example use of this would be a company that doesn't want their Capybara tests (all located in spec/features/) to run unless necessary. This way, Semaphore's build time can be reduced on all branches that don't need total build-accuracy. In this case, the company could use Semaphore's environment variable setter to enable:
+
+`REGRESSION_PATH=spec/features/`
+
+`EXEMPT_BRANCHES=master,release,develop`
+
+Additionally, the REGRESSION_PATH will be ignored if the build was manually created- meaning it was created by someone clicking 'Rebuild last revision' on Semaphore.
+
+### Commit Directives
+
+Further, test execution can be customised by commit directives. Commit directives are strings pulled from the most recent git commit. There are seven recognised commit directives:
+
+- [ci skip]
+  - Semaphore will not process this commit, will not create a build revision of it.
+- [cukes off]
+  - Cucumber tests wont run. This directive tells Semaphore not to execute any cucumber test files.
+- [specs off]
+  - Specs wont run. Same purpose as cukes off but for specs.
+- [minitest off]
+  - Minitest wont run.
+- [exunit off]
+  - ExUnit tests wont run.
+- [gotest off]
+  - GoTests wont run.
+- [regression]
+  - The REGRESSION_PATH is ignored, a full test-suite is run for this build. Useful if you want to be certain your code is green before pushing to release, master etc.
+
+These commit directives can be stacked as much as you would like, but be wary of using conflicting directives that might have unexpected behaviour.
+For example if `[regression]` and `[ci skip]` are both passed, ci skip will trump and no build revision will be made.
+
+In an example where a developer did not want their specs to run on a certain commit, they could use the commit message:
+
+``` git
+Misc changes to cucumber tests.
+
+Altered the setup file for our cucumber tests, shouldn't affect any of the specs.
+[specs off]
+```
+
+Note that it does not matter where the `[command]` is in the commit message.
 
 ## RSpec Booster
 

--- a/lib/test_boosters/boosters/rspec.rb
+++ b/lib/test_boosters/boosters/rspec.rb
@@ -28,7 +28,7 @@ module TestBoosters
         @rspec_options ||= begin
           output_formatter = ENV.fetch("TB_RSPEC_FORMATTER", "documentation")
           # rubocop:disable LineLength
-          "#{ENV["TB_RSPEC_OPTIONS"]} --format #{output_formatter} --require #{formatter_path} --format SemaphoreFormatter --out #{report_path} --profile"
+          "#{ENV["TB_RSPEC_OPTIONS"]} --format #{output_formatter} --require #{formatter_path} --format SemaphoreFormatter --out #{report_path}"
         end
       end
 

--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -31,7 +31,6 @@ module TestBoosters
         if source.eql?('manual')
           @exclude_path.delete(regression_path)
         end
-
         if last_msg.include?('[regression]')
           @exclude_path.delete(regression_path)
         end
@@ -40,6 +39,15 @@ module TestBoosters
         end
         if last_msg.include?('[specs off]')
           @exclude_path << '_spec.rb'
+        end
+        if last_msg.include?('[minitest off]')
+          @exclude_path << '_test.rb'
+        end
+        if last_msg.include?('[exunit off]')
+          @exclude_path << '_test.exs'
+        end
+        if last_msg.include?('[gotest off]')
+          @exclude_path << '_test.go'
         end
 
         @exclude_path

--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -38,9 +38,11 @@ module TestBoosters
         if last_msg.include?('[cukes off]')
           @exclude_path << '.feature'
         end
-        if last_msg.include?('[spec off]')
+        if last_msg.include?('[specs off]')
           @exclude_path << '_spec.rb'
         end
+
+        @exclude_path
       end
 
       def display_info

--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -11,6 +11,8 @@ module TestBoosters
         @file_pattern = file_pattern
         @job_count = job_count
         @exclude_path = ['spec/features/']
+
+        env_handler
       end
 
       def env_handler
@@ -48,11 +50,11 @@ module TestBoosters
       end
 
       def all_files
-        env_handler
+        is_valid = lambda { |x| x.nil? || x.empty? }
 
-        return Dir[@file_pattern].sort if @exclude_path.all? { |path| path.nil? || path.empty? }
+        return Dir[@file_pattern].sort if @exclude_path.all? { |path| is_valid[path] }
         Dir[@file_pattern].sort.reject do |path|
-          @exclude_path.any? { |word| path.include? word unless word.nil? || word.empty? }
+          @exclude_path.any? { |word| path.include?(word) unless is_valid[word] }
         end
       end
 

--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -60,11 +60,9 @@ module TestBoosters
       end
 
       def all_files
-        is_valid = lambda { |x| x.nil? || x.empty? }
-
-        return Dir[@file_pattern].sort if @exclude_path.all? { |path| is_valid[path] }
+        return Dir[@file_pattern].sort if @exclude_path.all? { |path| path.nil? || path.empty? }
         Dir[@file_pattern].sort.reject do |path|
-          @exclude_path.any? { |word| path.include?(word) unless is_valid[word] }
+          @exclude_path.any? { |word| path.include?(word) unless word.nil? || word.empty? }
         end
       end
 

--- a/spec/lib/test_boosters/file_exclude_spec.rb
+++ b/spec/lib/test_boosters/file_exclude_spec.rb
@@ -3,19 +3,29 @@ require 'spec_helper'
 describe 'Excluding a path from running when' do
   subject { distributor.all_files.any? { |f| f.include? banished_dir } }
 
-  let(:banished_dir) { '/features/' }
+  let(:banished_dir) { '/integration/' } # The regression path were going to test filtering out
   let(:file_pattern) { 'spec/**/*_spec.rb' } # The hardcoded pattern for rspec boosters
   let(:distributor) { TestBoosters::Files::Distributor.new(nil, file_pattern, 12) }
+
+  before do
+    ENV['EXEMPT_BRANCHES'] = 'master,develop,release'
+    ENV['REGRESSION_PATH'] = 'spec/integration/'
+  end
 
   after do
     ENV.delete('SEMAPHORE_TRIGGER_SOURCE')
     ENV.delete('BRANCH_NAME')
   end
 
-  context 'on a core branch' do
+  context 'on an exempt branch' do
     before { ENV['BRANCH_NAME'] = 'master' }
 
-    it 'files filtered out correctly' do
+    it 'with regression path' do
+      expect(subject).to be true
+    end
+
+    it 'without regression path' do
+      ENV.delete('REGRESSION_PATH')
       expect(subject).to be true
     end
   end
@@ -23,15 +33,25 @@ describe 'Excluding a path from running when' do
   context 'on an arbitrary branch' do
     before { ENV['BRANCH_NAME'] = 'abracadabra' }
 
-    it 'files filtered out correctly' do
+    it 'with regression path' do
       expect(subject).to be false
+    end
+
+    it 'without regression path' do
+      ENV.delete('REGRESSION_PATH')
+      expect(subject).to be true
     end
   end
 
   context 'when manually rebuilt' do
     before { ENV['SEMAPHORE_TRIGGER_SOURCE'] = 'manual' }
 
-    it 'files filtered correctly' do
+    it 'without branch specified' do
+      expect(subject).to be true
+    end
+
+    it 'on arbitrary branch' do
+      ENV['BRANCH_NAME'] = 'abracadabra'
       expect(subject).to be true
     end
   end
@@ -39,14 +59,29 @@ describe 'Excluding a path from running when' do
   context 'an automated push' do
     before { ENV['SEMAPHORE_TRIGGER_SOURCE'] = 'push' }
 
-    it 'files filtered correctly' do
+    it 'without branch specified' do
       expect(subject).to be false
+    end
+
+    it 'on an exempt branch' do
+      ENV['BRANCH_NAME'] = 'develop'
+      expect(subject).to be true
     end
   end
 
-  context 'nothing is specified' do
-    it 'features filtered out' do
-      expect(subject).to be false
+  context 'all environment variables' do
+    it 'deleted' do
+      ENV.clear
+      expect(subject).to be true
+    end
+
+    it 'with empty strings' do
+      ENV['EXEMPT_BRANCHES'] = ''
+      ENV['REGRESSION_PATH'] = ''
+      ENV['SEMAPHORE_TRIGGER_SOURCE'] = ''
+      ENV['BRANCH_NAME'] = ''
+
+      expect(subject).to be true
     end
   end
 end

--- a/spec/lib/test_boosters/file_exclude_spec.rb
+++ b/spec/lib/test_boosters/file_exclude_spec.rb
@@ -35,7 +35,6 @@ describe 'Excluding a path from running when' do
     before { ENV['BRANCH_NAME'] = 'abracadabra' }
 
     it 'with regression path' do
-      puts `git log -1`
       expect(subject).to be false
     end
 
@@ -109,6 +108,7 @@ describe 'Excluding a path from running when' do
     before { ENV['COMMIT_FILTER'] = '[specs off]' }
 
     it 'should filter out specs' do
+      expect(subject).to be false
     end
   end
 

--- a/spec/lib/test_boosters/file_exclude_spec.rb
+++ b/spec/lib/test_boosters/file_exclude_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Excluding a path from running when' do
-  subject { distributor.all_files.any? { |f| f.include? banished_dir } }
+  subject(:test_files_present) { distributor.all_files.any? { |f| f.include? banished_dir } }
 
   let(:banished_dir) { '/integration/' } # The regression path were going to test filtering out
   let(:file_pattern) { 'spec/**/*_spec.rb' } # The hardcoded pattern for rspec boosters
@@ -22,12 +22,12 @@ describe 'Excluding a path from running when' do
     before { ENV['BRANCH_NAME'] = 'master' }
 
     it 'with regression path' do
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
 
     it 'without regression path' do
       ENV.delete('REGRESSION_PATH')
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
   end
 
@@ -35,12 +35,12 @@ describe 'Excluding a path from running when' do
     before { ENV['BRANCH_NAME'] = 'abracadabra' }
 
     it 'with regression path' do
-      expect(subject).to be false
+      expect(test_files_present).to be false
     end
 
     it 'without regression path' do
       ENV.delete('REGRESSION_PATH')
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
   end
 
@@ -48,12 +48,12 @@ describe 'Excluding a path from running when' do
     before { ENV['SEMAPHORE_TRIGGER_SOURCE'] = 'manual' }
 
     it 'without branch specified' do
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
 
     it 'on arbitrary branch' do
       ENV['BRANCH_NAME'] = 'abracadabra'
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
   end
 
@@ -61,12 +61,12 @@ describe 'Excluding a path from running when' do
     before { ENV['SEMAPHORE_TRIGGER_SOURCE'] = 'push' }
 
     it 'without branch specified' do
-      expect(subject).to be false
+      expect(test_files_present).to be false
     end
 
     it 'on an exempt branch' do
       ENV['BRANCH_NAME'] = 'develop'
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
   end
 
@@ -75,7 +75,7 @@ describe 'Excluding a path from running when' do
       ENV.clear
       ENV['COMMIT_FILTER'] = ''
 
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
 
     it 'with empty strings' do
@@ -84,7 +84,7 @@ describe 'Excluding a path from running when' do
       ENV['SEMAPHORE_TRIGGER_SOURCE'] = ''
       ENV['BRANCH_NAME'] = ''
 
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
   end
 
@@ -92,14 +92,14 @@ describe 'Excluding a path from running when' do
     before { ENV['COMMIT_FILTER'] = '[regression]' }
 
     it 'shouldnt filter out anything' do
-      expect(subject).to be true
+      expect(test_files_present).to be true
     end
 
     context 'and [specs off]' do
       before { ENV['COMMIT_FILTER'] = '[regression]...[specs off]' }
 
       it 'should filter out all specs' do
-        expect(subject).to be false
+        expect(test_files_present).to be false
       end
     end
   end
@@ -108,7 +108,7 @@ describe 'Excluding a path from running when' do
     before { ENV['COMMIT_FILTER'] = '[specs off]' }
 
     it 'should filter out specs' do
-      expect(subject).to be false
+      expect(test_files_present).to be false
     end
   end
 


### PR DESCRIPTION
Changes in this PR:

- Removed hardcoding --profile into the rspec booster, will pass it as an ENV variable instead.
- Made all the exempt branch/regression path etc variables much more flexible, while still keeping them all opt-in.
- Added a lambda to dry up some repetitive logic.
- Updated the spec to test the right conditions, including stubbing the `git log -1` call

To make this feature more usable, it now relies on environment variables for operation (though doesnt _require_ them be set):

REGRESSION_PATH: the default path to be filtered out unless a full test suite is to be run.

EXEMPT_BRANCHES: branches that are exempt from the regression filtering. They will always run a full suite. Any number of branches can be passed as long as they are csv, i.e. 
`export EXEMPT_BRANCHES=develop,master,release`