### PR TITLE
Add ability to filter paths from manual load.

### DIFF
--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -81,7 +81,7 @@ module TestBoosters
       end
 
       def split_configuration
-        @split_configuration ||= TestBoosters::Files::SplitConfiguration.new(@split_configuration_path)
+        @split_configuration ||= TestBoosters::Files::SplitConfiguration.new(@split_configuration_path, @exclude_path)
       end
 
     end

--- a/lib/test_boosters/files/split_configuration.rb
+++ b/lib/test_boosters/files/split_configuration.rb
@@ -4,9 +4,10 @@ module TestBoosters
 
       Job = Struct.new(:files)
 
-      def initialize(path)
+      def initialize(path, exclude_path=[])
         @path = path
         @valid = true
+        @exclude_path = exclude_path
       end
 
       def present?
@@ -41,6 +42,10 @@ module TestBoosters
 
         content = JSON.parse(File.read(@path)).map do |raw_job|
           files = raw_job.fetch("files").sort
+
+          files.reject! do |f|
+            @exclude_path.any? { |word| f.include?(word) unless word.nil? || word.empty? }
+          end
 
           TestBoosters::Files::SplitConfiguration::Job.new(files)
         end

--- a/rspec_split_configuration.json
+++ b/rspec_split_configuration.json
@@ -1,5 +1,5 @@
 [
-  { "files": ["spec/features/job_management/actions_one_spec.rb"] },
+  { "files": ["spec/features/job_management/actions_one_spec.rb", "spec/features/precision/prescriptions/prescription_filter_spec.rb"] },
   { "files": ["spec/features/job_management/actions_two_spec.rb", "spec/features/maps/paddock_inspector_spec.rb"] },
   { "files": ["spec/features/job_management/actions_three_spec.rb", "spec/features/job_management/job_orders/set_order_spec.rb"] },
   { "files": ["spec/features/job_management/activity_spec.rb", "spec/features/users/trial_offer_spec.rb"] },
@@ -8,7 +8,7 @@
   { "files": ["spec/features/job_management/filter_two_spec.rb", "spec/services/precision/layer_service_spec.rb"] },
   { "files": ["spec/features/job_management/filter_three_spec.rb", "spec/features/users/two_factor_auth_login_spec.rb"] },
   { "files": ["spec/features/job_management/maps_one_spec.rb"] },
-  { "files": ["spec/features/job_management/maps_two_spec.rb"] },
+  { "files": ["spec/features/job_management/maps_two_spec.rb", "spec/features/precision/prescriptions/prescription_bulk_actions_spec.rb"] },
   { "files": ["spec/features/job_management/my_business_spec.rb", "spec/features/job_management/performance_reporting_spec.rb", "spec/features/job_management/precision_apps_spec.rb"] },
   { "files": ["spec/features/job_management/change_due_dates_spec.rb", "spec/features/job_management/convert_job_spec.rb"] }
 ]

--- a/rspec_split_configuration.json
+++ b/rspec_split_configuration.json
@@ -1,0 +1,14 @@
+[
+  { "files": ["spec/features/job_management/actions_one_spec.rb"] },
+  { "files": ["spec/features/job_management/actions_two_spec.rb", "spec/features/maps/paddock_inspector_spec.rb"] },
+  { "files": ["spec/features/job_management/actions_three_spec.rb", "spec/features/job_management/job_orders/set_order_spec.rb"] },
+  { "files": ["spec/features/job_management/activity_spec.rb", "spec/features/users/trial_offer_spec.rb"] },
+  { "files": ["spec/features/job_management/activity_two_spec.rb", "spec/features/signup/signup_user_spec.rb"] },
+  { "files": ["spec/features/job_management/filter_one_spec.rb", "spec/features/precision/report_spec.rb"] },
+  { "files": ["spec/features/job_management/filter_two_spec.rb", "spec/services/precision/layer_service_spec.rb"] },
+  { "files": ["spec/features/job_management/filter_three_spec.rb", "spec/features/users/two_factor_auth_login_spec.rb"] },
+  { "files": ["spec/features/job_management/maps_one_spec.rb"] },
+  { "files": ["spec/features/job_management/maps_two_spec.rb"] },
+  { "files": ["spec/features/job_management/my_business_spec.rb", "spec/features/job_management/performance_reporting_spec.rb", "spec/features/job_management/precision_apps_spec.rb"] },
+  { "files": ["spec/features/job_management/change_due_dates_spec.rb", "spec/features/job_management/convert_job_spec.rb"] }
+]

--- a/spec/lib/test_boosters/files/split_configuration_spec.rb
+++ b/spec/lib/test_boosters/files/split_configuration_spec.rb
@@ -115,6 +115,21 @@ describe TestBoosters::Files::SplitConfiguration do
         expect(configuration.jobs[2].files).to eq []
       end
     end
-  end
 
+    context "filter path is present" do
+      before { @exclude_path = ['c_', '', nil, 'abd'] }
+
+      subject(:configuration) { described_class.new(@path, @exclude_path) }
+
+      it { is_expected.to be_present }
+
+      describe "filtering" do
+        it "puts every file to its proper job instance" do
+          expect(configuration.jobs[0].files).to eq ["a_spec.rb", "d_spec.rb"]
+          expect(configuration.jobs[1].files).to eq ["b_spec.rb", "f_spec.rb"]
+          expect(configuration.jobs[2].files).to eq []
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This update brings in manual balancing for the slowest specs in our repo. The hope is that if the most time-intensive specs are properly distributed, then semaphore is only in charge of the short specs, and can only screw up so much.

Normally this manual split config would over-write any commit directives as it is called independent of Distributor, but i've added in a filter so the directives take precedence.

My only concern is that a lot of the manually allocated files don't exist on every branch- so what happens when a branch without these files is built?
Nothing? Split config error? Pandoras box opens? Lets find out.