### PR TITLE
Feature/rspec rerun

### DIFF
--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -11,47 +11,6 @@ module TestBoosters
         @file_pattern = file_pattern
         @job_count = job_count
         @exclude_path = []
-
-        env_handler
-      end
-
-      def env_handler
-        last_msg = `git log -1`
-        changed_files = `git diff HEAD~1 --name-only`
-        regression_path = ENV['REGRESSION_PATH']
-        source = ENV['SEMAPHORE_TRIGGER_SOURCE']
-        current_branch = ENV['BRANCH_NAME']
-        exempt_branches =
-         if ENV['EXEMPT_BRANCHES'].nil?
-           []
-         else
-           ENV['EXEMPT_BRANCHES'].split(',')
-        end
-
-        @exclude_path << regression_path unless exempt_branches.include?(current_branch)
-        if source.eql?('manual')
-          @exclude_path.delete(regression_path)
-        end
-        if last_msg.include?('[regression]') || changed_files.include?(regression_path)
-          @exclude_path.delete(regression_path)
-        end
-        if last_msg.include?('[cukes off]')
-          @exclude_path << '.feature'
-        end
-        if last_msg.include?('[specs off]')
-          @exclude_path << '_spec.rb'
-        end
-        if last_msg.include?('[minitest off]')
-          @exclude_path << '_test.rb'
-        end
-        if last_msg.include?('[exunit off]')
-          @exclude_path << '_test.exs'
-        end
-        if last_msg.include?('[gotest off]')
-          @exclude_path << '_test.go'
-        end
-
-        @exclude_path
       end
 
       def display_info

--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -17,6 +17,7 @@ module TestBoosters
 
       def env_handler
         last_msg = `git log -1`
+        changed_files = `git diff HEAD~1 --name-only`
         regression_path = ENV['REGRESSION_PATH']
         source = ENV['SEMAPHORE_TRIGGER_SOURCE']
         current_branch = ENV['BRANCH_NAME']
@@ -31,7 +32,7 @@ module TestBoosters
         if source.eql?('manual')
           @exclude_path.delete(regression_path)
         end
-        if last_msg.include?('[regression]')
+        if last_msg.include?('[regression]') || changed_files.include?(regression_path)
           @exclude_path.delete(regression_path)
         end
         if last_msg.include?('[cukes off]')

--- a/lib/test_boosters/job.rb
+++ b/lib/test_boosters/job.rb
@@ -24,6 +24,16 @@ module TestBoosters
       @all_files ||= @known_files + @leftover_files
     end
 
+    def rspec_rerun
+      rerun_files = ''
+      File.open('rspec_rerun.txt') do |f|
+        f.each_line { |line| rerun_files += line unless line.nil? }
+      end
+      rerun_files
+    rescue Errno::ENOENT
+      '' # Return empty string
+    end
+
     def run
       display_header
 
@@ -35,6 +45,14 @@ module TestBoosters
 
       if @command.include?('cucumber')
         TestBoosters::Shell.execute("#{@command} --strict -f rerun --out rerun.txt #{files.join(' ')} || #{@command} --strict @rerun.txt")
+      elsif @command.include?('rspec')
+        exit_status = TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
+        # Run our retry
+        if rspec_rerun.empty?
+          exit_status
+        else
+          TestBoosters::Shell.execute("#{@command} #{rspec_rerun}") unless rspec_rerun.empty?
+        end
       else
         TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
       end

--- a/lib/test_boosters/job.rb
+++ b/lib/test_boosters/job.rb
@@ -47,12 +47,7 @@ module TestBoosters
         TestBoosters::Shell.execute("#{@command} --strict -f rerun --out rerun.txt #{files.join(' ')} || #{@command} --strict @rerun.txt")
       elsif @command.include?('rspec')
         exit_status = TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
-        # Run our retry
-        if rspec_rerun.empty?
-          exit_status
-        else
-          TestBoosters::Shell.execute("#{@command} #{rspec_rerun}") unless rspec_rerun.empty?
-        end
+        rspec_rerun.empty? ? exit_status : TestBoosters::Shell.execute("#{@command} #{rspec_rerun}")
       else
         TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
       end

--- a/lib/test_boosters/job.rb
+++ b/lib/test_boosters/job.rb
@@ -30,8 +30,7 @@ module TestBoosters
     end
 
     def rerun_files_exist?
-      return false unless File.exist?("tmp/capybara")
-      true
+      File.exist?("tmp/capybara/rspec_rerun.txt")
     end
 
     def run
@@ -39,6 +38,7 @@ module TestBoosters
 
       if files.empty?
         puts("No files to run in this job!")
+
         return 0
       end
 
@@ -54,8 +54,8 @@ module TestBoosters
         # Some scenarios were marked for re-run, so return the result of our second pass
         TestBoosters::Shell.execute("#{@command} #{rerun_files}")
 
+      # Running Go / minitest etc - no re-runs
       else
-        # Running Go / minitest etc
         TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
       end
     end

--- a/lib/test_boosters/job.rb
+++ b/lib/test_boosters/job.rb
@@ -47,12 +47,11 @@ module TestBoosters
         TestBoosters::Shell.execute("#{@command} --strict -f rerun --out rerun.txt #{files.join(' ')} || #{@command} --strict @rerun.txt")
       elsif @command.include?('rspec')
         exit_status = TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
-        # Run our retry
         if rspec_rerun.empty?
           exit_status
         else
-          TestBoosters::Shell.execute("#{@command} #{rspec_rerun}") unless rspec_rerun.empty?
-        end
+          rerun_status = TestBoosters::Shell.execute("#{@command} #{rspec_rerun}")
+          exit_status && rerun_status
       else
         TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
       end

--- a/lib/test_boosters/job.rb
+++ b/lib/test_boosters/job.rb
@@ -52,6 +52,7 @@ module TestBoosters
         else
           rerun_status = TestBoosters::Shell.execute("#{@command} #{rspec_rerun}")
           exit_status && rerun_status
+        end
       else
         TestBoosters::Shell.execute("#{@command} #{files.join(" ")}")
       end


### PR DESCRIPTION
Changes in this PR:
- Remove all handing of commit directives (regression etc). That's all done much faster in website.
- Re-run RSpec examples that have been marked for it after the first pass.

test-boosters don't determines IF an example should be re-run, that's all done in website.
The boosters just run the list they're provided with.